### PR TITLE
Change localhost port to 8081

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ tasks.register('buildImage', Exec) {
 
 tasks.register('startContainer', Exec) {
     workingDir "$projectDir"
-    commandLine 'docker', 'run', '-d', '--name', CONTAINER_NAME, '--rm', '-p8080:8080', "$DOCKER_ACCOUNT/$DOCKER_REPO:latest"
+    commandLine 'docker', 'run', '-d', '--name', CONTAINER_NAME, '--rm', '-p8081:8080', "$DOCKER_ACCOUNT/$DOCKER_REPO:latest"
      
     doLast { 	
         sleep(10000)
@@ -71,7 +71,7 @@ tasks.register('checkUsabilityHub') {
     group = GROUP
     description = "Check usability hub (very naïve approach)"
     doLast {
-        def response = ["curl", "-i", "-v", "-X", "GET", "http://localhost:8080/ilidata.xml"].execute().text
+        def response = ["curl", "-i", "-v", "-X", "GET", "http://localhost:8081/ilidata.xml"].execute().text
         println(response)
 
         if (!response.contains("HTTP/2 200") && !response.contains("DatasetIdx16.DataIndex.DatasetMetadata")) {


### PR DESCRIPTION
@edigonzales Spricht etwas dagegen, den Port des Usability Hubs für die lokale Entwicklung auf 8081 zu ändern?

So kann man gleichzeitig das Modell Repository auf localhost:8080 laufen lassen und den Usability Hub auf localhost:8081 und z.B. in QGIS Model Baker lokale Modelle und lokale Toppings testen.