### PR TITLE
Update gh workflow to latest action versions (support for Node.js 20)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
@@ -45,13 +45,13 @@ jobs:
         if: ${{ success() }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
@edigonzales Wir haben da deprecation Warnings für die GitHub actions. Ich habe die Versionen mal entsprechend erhöht, müssen wir da noch etwas bestimmtes beachten, oder können wir diese actions risikolos aktualisieren?

Dasselbe gilt auch für sogis-interlis-repository.